### PR TITLE
Add cmake support for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bin/*
 html/
 latex/
 build/*
+.idea/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,22 @@ project(libk2tree)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 find_package(libcds2 REQUIRED)
+include(ExternalProject)
+include(find_or_download_package)
+find_or_download_package(GTest GTEST gtest)
+#find_or_download_package(Boost Boost boost COMPONENTS system filesystem regex)
+find_package(Boost COMPONENTS system filesystem regex)
+
+
+include_directories($GTEST_INCLUDE_DIRS)
+include_directories(${CMAKE_SOURCE_DIR}/include)
+include_directories(${CMAKE_SOURCE_DIR}/dacs/include)
+include_directories(${CMAKE_SOURCE_DIR}/src)
+include_directories(${Boost_INCLUDE_DIRS})
+
+set(Boost_USE_STATIC_LIBS OFF)
+set(Boost_USE_MULTITHREADED ON)
+set(Boost_USE_STATIC_RUNTIME OFF)
 
 set(LIBK2TREE_NAME "k2tree")
 
@@ -25,5 +41,6 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -Wconversion -Wsign-co
 
 add_subdirectory(src)
 add_subdirectory(dacs)
+add_subdirectory(tests)
 
 set(CMAKE_BUILD_TYPE Release)

--- a/cmake/Modules/DownloadBoost.cmake
+++ b/cmake/Modules/DownloadBoost.cmake
@@ -1,0 +1,22 @@
+ExternalProject_Add(
+    boost_external
+    GIT_REPOSITORY https://github.com/boostorg/boost.git
+    GIT_TAG boost-1.59.0
+    UPDATE_COMMAND ""
+    BUILD_IN_SOURCE 1
+    CONFIGURE_COMMAND ./bootstrap.sh
+    BUILD_COMMAND ./b2 --prefix=<INSTALL_DIR> --without-python install
+    #BUILD_COMMAND ./b2 --show-libraries
+    INSTALL_COMMAND ""
+)
+ExternalProject_Get_Property(boost_external source_dir install_dir)
+
+file(MAKE_DIRECTORY "${install_dir}/include")
+
+set(${package_found_prefix}_CMAKE_DEP boost_external)
+set(${package_found_prefix}_LIBRARIES
+    "${install_dir}/lib/libboost_system.a"
+    "${install_dir}/lib/libboost_filesystem.a"
+    "${install_dir}/lib/libboost_program_options.a"
+)
+set(${package_found_prefix}_INCLUDE_DIRS "${install_dir}/include")

--- a/cmake/Modules/DownloadGTest.cmake
+++ b/cmake/Modules/DownloadGTest.cmake
@@ -1,0 +1,14 @@
+ExternalProject_Add(
+    gtest_external
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+    UPDATE_COMMAND ""
+)
+ExternalProject_Get_Property(gtest_external source_dir install_dir)
+
+file(MAKE_DIRECTORY "${install_dir}/include")
+
+set(${package_found_prefix}_CMAKE_DEP test_external)
+set(${package_found_prefix}_LIBRARIES "${install_dir}/lib/libgtest.a"
+                                        "${install_dir}/lib/libgtest_main.a")
+set(${package_found_prefix}_INCLUDE_DIRS "${install_dir}/include")

--- a/cmake/Modules/find_or_download_package.cmake
+++ b/cmake/Modules/find_or_download_package.cmake
@@ -1,0 +1,42 @@
+function(find_or_download_package package package_found_prefix target_name)
+    find_package(${package} ${ARGN})
+
+    if(${package_found_prefix}_FOUND)
+        message(STATUS "${package} found, no need to build locally")
+    else()
+        message(STATUS "${package} not found, will download and build locally")
+        include(Download${package})
+    endif()
+
+    add_library(${target_name} INTERFACE)
+
+    foreach(sublib ${${package_found_prefix}_LIBRARIES})
+        get_filename_component(LIB_NAME ${sublib} NAME_WE)
+        set(sublib_target ${package}_cmake_dep_${LIB_NAME})
+
+        message(STATUS ${sublib} "  " ${sublib_target})
+
+        # Detect wether this is a shared or a static library
+        # NB: This might not work on windows
+        get_filename_component(LIB_EXT ${sublib} EXT)
+        if(${LIB_EXT} STREQUAL ${CMAKE_STATIC_LIBRARY_SUFFIX})
+            add_library(${sublib_target} IMPORTED STATIC GLOBAL)
+        else()
+            add_library(${sublib_target} IMPORTED SHARED GLOBAL)
+        endif()
+
+        foreach(sublib_target_dep ${${package_found_prefix}_CMAKE_DEP})
+            message(STATUS "sublib target dep: " ${sublib_target_dep})
+            add_dependencies(${sublib_target} ${sublib_target_dep})
+        endforeach()
+
+        set_target_properties(${sublib_target} PROPERTIES
+            "IMPORTED_LOCATION" "${sublib}"
+            "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
+            "INTERFACE_INCLUDE_DIRECTORIES" "${${package_found_prefix}_INCLUDE_DIRS}"
+        )
+        target_link_libraries(${target_name} INTERFACE
+            ${sublib_target})
+    endforeach(sublib)
+
+endfunction()

--- a/dacs/src/directcodes.c
+++ b/dacs/src/directcodes.c
@@ -124,7 +124,7 @@ ushort * optimizationk(uint * acumFreqs,int maxInt, uint * nkvalues) {
   ulong maxSize = 0, maxPos = 0;
   int posVocInf, posVocSup;
   ulong currentSize;
-  //Para la optimizacion, hay que mirar el máximo de todas las opciones anteriores anhadiendo
+  //Para la optimizacion, hay que mirar el mÃ¡ximo de todas las opciones anteriores anhadiendo
   //hasta el bit actual
 
   tableSize[0]=0;
@@ -232,6 +232,7 @@ FTRep* createFT(uint *list,uint listLength){
   rep->listLength = listLength;
   register uint i;
   int j, k;
+  uint l;
   uint value, newvalue;
   uint bits_BS_len = 0;
 
@@ -251,8 +252,8 @@ FTRep* createFT(uint *list,uint listLength){
   uint * weight = (uint *) malloc(sizeof(uint)*maxInt);
 
 
-  for(uint i=0; i<maxInt; i++)
-    weight[i] = 0;
+  for(l=0; l<maxInt; l++)
+    weight[l] = 0;
 
   for(i=0;i<listLength;i++)
     weight[list[i]]++;
@@ -376,7 +377,7 @@ FTRep* createFT(uint *list,uint listLength){
 
 
   rep->levels = (uint *) malloc(sizeof(uint)*(tamLevels/W+1));
-  //fprintf(stderr,"tamaño de levels: %d\n",sizeof(uint)*(tamLevels/W+1));
+  //fprintf(stderr,"tamaÃ±o de levels: %d\n",sizeof(uint)*(tamLevels/W+1));
   bits_BS_len = rep->levelsIndex[rep->nLevels-1]+1; 
   //Se pone el ultimo a 0 para ahorrarnos comparaciones despues en la descompresion
   uint * bits_BS = (uint *) malloc(sizeof(uint)*(bits_BS_len/W+1));

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,4 @@
+enable_testing()
+
+add_executable(test_libk2tree test_main.cc queries.cc)
+target_link_libraries(test_libk2tree ${GTEST_LIBRARIES} rt gtest ${LIBK2TREE_NAME} ${Boost_LIBRARIES} pthread boost_system boost_filesystem)

--- a/tests/queries.cc
+++ b/tests/queries.cc
@@ -8,6 +8,9 @@
  */
 
 
+#ifndef TESTS_QUERIES_CC_
+#define TESTS_QUERIES_CC_
+
 #include "./queries.h"
 #include <vector>
 
@@ -35,4 +38,4 @@ vector<uint> GetPredecessors(const vector<vector<bool> > &matrix, uint q) {
   return v;
 }
 
-
+#endif // TESTS_QUERIES_CC_

--- a/tests/test_compressed_partition.cc
+++ b/tests/test_compressed_partition.cc
@@ -16,7 +16,7 @@
 #include <memory>
 #include "./queries.h"
 
-uing ::libk2tree::K2TreePartitionBuilder;
+using ::libk2tree::K2TreePartitionBuilder;
 using ::libk2tree::utils::Ceil;
 using ::libk2tree::K2TreePartition;
 using ::libk2tree::CompressedPartition;

--- a/tests/test_main.cc
+++ b/tests/test_main.cc
@@ -9,6 +9,13 @@
 
 #include <gtest/gtest.h>
 #include <pthread.h>
+#include "test_bitarray.cc"
+#include "test_compressed_hybrid.cc"
+#include "test_compressed_partition.cc"
+#include "test_k2tree.cc"
+#include "test_k2treebuilder.cc"
+#include "test_k2treepartition.cc"
+#include "test_utils.cc"
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Hello nilehmann,

I added cmake support for the test cases.
Note that the find_and_download script used is from https://github.com/tudocomp/tudocomp and under GPL3.0. 

Best Regards,
Jan
